### PR TITLE
Refactor isRecordLoaded into an observer to set default value at init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Cleaned up code syntax to match airbnb's javascript style guide and eslint.
 - Fix visual filter layout bug to use component element wrappers and refactor component templates to reduce bloat.
 - When clearing filter of relationships, dot notation was not maintained.
+- `isRecordLoaded` is now setup to have a default value of `false` by refactoring to use observers instead of a computed property.

--- a/addon/components/ember-tabular.js
+++ b/addon/components/ember-tabular.js
@@ -190,7 +190,7 @@ export default Ember.Component.extend({
     return segments;
   },
 
-  setIsRecordLoaded: Ember.on('init', Ember.observer('errors', 'record', 'record.isFulfilled',
+  setIsRecordLoaded: Ember.observer('errors', 'record', 'record.isFulfilled',
   'record.isLoaded', 'modelName', function () {
     // If record array isLoaded but empty
     if (this.get('record.isLoaded')) {
@@ -212,7 +212,7 @@ export default Ember.Component.extend({
     if (this.get('record') === null && this.get('modelName') === null) {
       this.set('isRecordLoaded', true);
     }
-  })),
+  }),
 
   isColumnFilters: Ember.computed('columns', function () {
     const columns = this.get('columns');

--- a/addon/components/ember-tabular.js
+++ b/addon/components/ember-tabular.js
@@ -8,6 +8,7 @@ export default Ember.Component.extend({
   showFilterRow: false,
   sortableClass: 'sortable',
   tableLoadedMessage: 'No Data.',
+  isRecordLoaded: false,
   columnLength: Ember.computed('columns', function () {
     return this.get('columns').length;
   }),
@@ -189,31 +190,29 @@ export default Ember.Component.extend({
     return segments;
   },
 
-  isrecordLoaded: Ember.computed('errors', 'record', 'record.isFulfilled', 'record.isLoaded',
-  'modelName', function () {
+  setIsRecordLoaded: Ember.on('init', Ember.observer('errors', 'record', 'record.isFulfilled',
+  'record.isLoaded', 'modelName', function () {
     // If record array isLoaded but empty
     if (this.get('record.isLoaded')) {
-      return true;
+      this.set('isRecordLoaded', true);
     }
     // If record.content array loaded is empty
     if (this.get('record.isFulfilled')) {
-      return true;
+      this.set('isRecordLoaded', true);
     }
     // If errors
     if (this.get('errors')) {
-      return true;
+      this.set('isRecordLoaded', true);
     }
     // If record array is empty
     if (this.get('record') && this.get('record').length === 0) {
-      return true;
+      this.set('isRecordLoaded', true);
     }
     // Show custom tableLoadedMessage
     if (this.get('record') === null && this.get('modelName') === null) {
-      return true;
+      this.set('isRecordLoaded', true);
     }
-
-    return false;
-  }),
+  })),
 
   isColumnFilters: Ember.computed('columns', function () {
     const columns = this.get('columns');

--- a/app/templates/components/ember-tabular.hbs
+++ b/app/templates/components/ember-tabular.hbs
@@ -63,7 +63,7 @@
                 {{else}}
                     <tr>
                         <td class="text-center" colspan="{{columnLength}}">
-                            {{#if isrecordLoaded}}
+                            {{#if isRecordLoaded}}
                                 {{tableLoadedMessage}}
                             {{else}}
                                 Loading...

--- a/tests/integration/ember-tabular-test.js
+++ b/tests/integration/ember-tabular-test.js
@@ -213,3 +213,17 @@ test('Render isLoading class on component', function(assert) {
   var $component = this.$();
   assert.equal($component.find('.table').hasClass('loading'), true, 'Table has class loading');
 });
+
+test('Render No Data on component', function(assert) {
+  this.set('columns', columns);
+  this.render(hbs`
+    {{#ember-tabular columns=columns record=[] makeRequest=false as |section|}}
+      {{#if section.isBody}}
+        ...
+      {{/if}}
+    {{/ember-tabular}}
+  `);
+
+  var $component = this.$();
+  assert.equal($component.find('.table tbody').text().trim(), 'No Data.', 'Table displays No Data.');
+});

--- a/tests/integration/ember-tabular-test.js
+++ b/tests/integration/ember-tabular-test.js
@@ -214,7 +214,7 @@ test('Render isLoading class on component', function(assert) {
   assert.equal($component.find('.table').hasClass('loading'), true, 'Table has class loading');
 });
 
-test('Render No Data on component', function(assert) {
+test('Render Loading... on component', function(assert) {
   this.set('columns', columns);
   this.render(hbs`
     {{#ember-tabular columns=columns record=[] makeRequest=false as |section|}}
@@ -225,5 +225,5 @@ test('Render No Data on component', function(assert) {
   `);
 
   var $component = this.$();
-  assert.equal($component.find('.table tbody').text().trim(), 'No Data.', 'Table displays No Data.');
+  assert.equal($component.find('.table tbody').text().trim(), 'Loading...', 'Table displays Loading.');
 });


### PR DESCRIPTION
#### What does this pull request do?
Refactor `isRecordLoaded` to be set within an observer which allows default value to be set for `isRecordLoaded`.

#### What are the relevant issues?
#50

#### Any background context you want to provide?
N/A

#### Definition of Done:
*Each should be selected to indicate consideration for applicability and/or completion.*

- [ ] Does this PR fully satisfy the scope as outlined in the referenced issue(s)?
- [ ] Is there appropriate test coverage?
- [ ] Is static analysis resulting in a satisfactory score?
- [ ] If adding new dependencies, does pip requirements need to be updated?
- [ ] Has the change log been updated?