### PR TITLE
Setup autoHide for the limit dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Adds feature that allows ember-tabular to wait until controller is ready for request to fire.
 - Add additional configurable wrapper classes for additional styling.
 - Add subcomponent to change the table limit/count.
+- Setup `autoHide` computed property to conditionally hide the limit dropdown if the results are smaller than the smallest pagination limit.
 
 ### Changed
 - Update legacy name references in README.md.

--- a/addon/components/ember-tabular-dropdown-limit.js
+++ b/addon/components/ember-tabular-dropdown-limit.js
@@ -6,4 +6,17 @@ export default Ember.Component.extend({
 
   // populates limit dropdown
   limits: [10, 25, 50, 100, 500],
+
+  autoHide: Ember.computed('record', 'count', function() {
+    let record = this.get('record');
+    let count = this.get('count');
+    let firstLimit = this.get('limits')[0];
+    if (record) {
+      let resultsLength = record.get('length');
+      if (resultsLength > firstLimit || (resultsLength === firstLimit && count > 1)) {
+        return true;
+      }
+    }
+    return false;
+  }),
 });

--- a/app/templates/components/ember-tabular-dropdown-limit.hbs
+++ b/app/templates/components/ember-tabular-dropdown-limit.hbs
@@ -1,16 +1,18 @@
-<div class="form-group form-inline text-right">
-    <label class="control-label" for="limit">
-        Show
-    </label>
-    {{#power-select
-        options=limits
-        selected=limit
-        searchField="label"
-        searchEnabled=false
-        placeholder="Select the table count"
-        class="limit text-left form-control-inline"
-        onchange=(action (mut limit))
-        as |size|}}
-            {{size}}
-    {{/power-select}}
-</div>
+{{#if autoHide}}
+    <div class="form-group form-inline text-right">
+        <label class="control-label" for="limit">
+            Show
+        </label>
+        {{#power-select
+            options=limits
+            selected=limit
+            searchField="label"
+            searchEnabled=false
+            placeholder="Select the table count"
+            class="limit text-left form-control-inline"
+            onchange=(action (mut limit))
+            as |size|}}
+                {{size}}
+        {{/power-select}}
+    </div>
+{{/if}}

--- a/app/templates/components/ember-tabular.hbs
+++ b/app/templates/components/ember-tabular.hbs
@@ -85,7 +85,7 @@
     </div>
     {{#if isDropdownLimit}}
         <div class="col-sm-3">
-            {{ember-tabular-dropdown-limit limit=limit}}
+            {{ember-tabular-dropdown-limit limit=limit record=record count=pageLimit}}
         </div>
     {{/if}}
 </div>

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -73,6 +73,22 @@ test('Check for proper row count when dropdown-limit is changed', function(asser
   });
 });
 
+test('Check for dropdown-limit autoHide', function(assert) {
+  server.createList('user', 10);
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentPath(), 'index');
+
+    let rows = find('.table-default table tbody tr');
+    assert.equal(rows.length, 10, 'Check for 10 items in table');
+
+    andThen(function() {
+      assert.equal(find('.table-default .ember-tabular-dropdown-limit > *').length, 0, 'ember-tabular-dropdown-limit is hidden');
+    });
+  });
+});
+
 test('Check for error handling', function(assert) {
   server.get('/users',
     {

--- a/tests/integration/ember-tabular-test.js
+++ b/tests/integration/ember-tabular-test.js
@@ -102,7 +102,7 @@ test('Render header yield', function(assert) {
 test('Render body yield', function(assert) {
   this.set('columns', columns);
   this.render(hbs`
-    {{#ember-tabular columns=columns record=record makeRequest=false as |section|}}
+    {{#ember-tabular columns=columns record=record makeRequest=false isDropdownLimit=false as |section|}}
       {{#if section.isBody}}
         <div class="body">
           Test Body Yield


### PR DESCRIPTION
#### What does this pull request do?
Sets up `autoHide` computed property to hide the limit dropdown if the results length is smaller than the smallest `limits` default.

#### What are the relevant issues?
#65 

#### Any background context you want to provide?
N/A

#### Definition of Done:
*Each should be selected to indicate consideration for applicability and/or completion.*

- [x] Does this PR fully satisfy the scope as outlined in the referenced issue(s)?
- [x] Is there appropriate test coverage?
- [x] Is static analysis resulting in a satisfactory score?
- [x] If adding new dependencies, does pip requirements need to be updated?
- [x] Has the change log been updated?