### PR TITLE
Upgrades ember-power-select dependency to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update legacy name references in README.md.
 - Removed ember-canary from ember-try testing scenarios.
 - Removed ember-beta from ember-try testing scenarios.
+- Upgrades ember-power-select to 1.0.0, may require refactoring of `class` to `triggerClass` if applicable.
 
 ### Fixed
 - Fix erring ember try in ember-canary, properly remove component element wrapper.

--- a/app/templates/components/ember-tabular-dropdown-limit.hbs
+++ b/app/templates/components/ember-tabular-dropdown-limit.hbs
@@ -9,7 +9,7 @@
             searchField="label"
             searchEnabled=false
             placeholder="Select the table count"
-            class="limit text-left form-control-inline"
+            triggerClass="limit text-left form-control-inline"
             onchange=(action (mut limit))
             as |size|}}
                 {{size}}

--- a/app/templates/components/ember-tabular-filter.hbs
+++ b/app/templates/components/ember-tabular-filter.hbs
@@ -5,7 +5,7 @@
             selected=(find-by header.list 'value' headerFilter)
             searchField="label"
             searchEnabled=false
-            class="ember-tabular-ember-power-select"
+            triggerClass="ember-tabular-ember-power-select"
             allowClear=true
             onchange=(action "setHeaderFilter")
             as |option|}}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-moment": "6.0.0",
-    "ember-power-select": "0.10.10",
+    "ember-power-select": "1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
     "loader.js": "^4.0.0",
@@ -59,7 +59,7 @@
     "ember-cli-babel": "^5.1.5",
     "pagination-pager": "2.4.1",
     "ember-truth-helpers": "1.2.0",
-    "ember-power-select": "0.10.10",
+    "ember-power-select": "1.0.0",
     "broccoli-merge-trees": "^0.2.3",
     "broccoli-funnel": "^1.0.0"
   },

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -547,7 +547,7 @@ test('Check table-basic-global-date-filter for date clearFilter action success',
   });
 });
 
-test('Check table-default for persistent filters on transition', function(assert) {
+test('Check table-persist for persistent filters on transition', function(assert) {
   server.loadFixtures('users');
   visit('/');
 
@@ -556,17 +556,17 @@ test('Check table-default for persistent filters on transition', function(assert
   });
 
   andThen(function() {
-    assert.equal(find('.table-default table tbody tr').length, 10, 'Check for 10 item in table');
+    assert.equal(find('.table-persist table tbody tr').length, 10, 'Check for 10 item in table');
   });
 
   andThen(function() {
-    click('.table-default table .btn-toggle-filter:eq(0)');
-    fillIn('.table-default table thead tr:eq(1) th:eq(3) input', 'McClane');
-    find('.table-default table thead tr:eq(1) th:eq(3) input').trigger('keyup');
+    click('.table-persist table .btn-toggle-filter:eq(0)');
+    fillIn('.table-persist table thead tr:eq(1) th:eq(3) input', 'McClane');
+    find('.table-persist table thead tr:eq(1) th:eq(3) input').trigger('keyup');
   });
 
   andThen(function() {
-    assert.equal(find('.table-default table tbody tr').length, 2, 'Check for 2 item in table');
+    assert.equal(find('.table-persist table tbody tr').length, 2, 'Check for 2 item in table');
   });
 
   andThen(function() {
@@ -580,17 +580,17 @@ test('Check table-default for persistent filters on transition', function(assert
   });
 
   andThen(function() {
-    assert.equal(find('.table-default table tbody tr').length, 2, 'Check for 2 item in table');
+    assert.equal(find('.table-persist table tbody tr').length, 2, 'Check for 2 item in table');
 
-    click('.table-default table .btn-toggle-filter:eq(0)');
+    click('.table-persist table .btn-toggle-filter:eq(0)');
     andThen(function() {
-      assert.equal(find('.table-default table thead tr:eq(1) th:eq(3) input').val(), 'McClane', 'Check for populated filter on transition');
+      assert.equal(find('.table-persist table thead tr:eq(1) th:eq(3) input').val(), 'McClane', 'Check for populated filter on transition');
     });
 
     andThen(function() {
       let request = getPretenderRequest(server, 'GET', 'users');
 
-      assert.equal(request.length, 8, 'Check that additional request was not made when opening filter row');
+      assert.equal(request.length, 10, 'Check that additional request was not made when opening filter row');
     });
   });
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -4,6 +4,7 @@ export default Ember.Controller.extend({
   users: null,
   users2: null,
   users3: null,
+  users4: null,
   filter: null,
   filter2: null,
   filter3: null,

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -69,7 +69,7 @@
                         searchField="label"
                         searchEnabled=false
                         placeholder="Select to filter"
-                        class="ember-tabular-ember-power-select"
+                        triggerClass="ember-tabular-ember-power-select"
                         allowClear=true
                         onchange=(action "setIsAdminFilter")
                         as |option|}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,8 +1,42 @@
 <h5>Example #1</h5>
 <h1>Table - Default</h1>
-{{#ember-tabular class="table-default" tableWrapperClass="table-wrapper" paginationWrapperClass="pagination-wrapper" columns=columns modelName="user" record=users filter=filter3 persistFiltering=true sort=sort as |section|}}
+{{#ember-tabular class="table-default" tableWrapperClass="table-wrapper" paginationWrapperClass="pagination-wrapper" columns=columns modelName="user" record=users as |section|}}
     {{#if section.isBody}}
         {{#each users as |row|}}
+            <tr>
+                <td>{{row.username}}</td>
+                <td>{{row.emailAddress}}</td>
+                <td>{{row.firstName}}</td>
+                <td>{{row.lastName}}</td>
+                <td>
+                    {{#if row.isAdmin}}
+                        Yes
+                    {{else}}
+                        No
+                    {{/if}}
+                </td>
+                <td>
+                    {{#if row.updatedAt}}
+                        {{moment-format row.updatedAt 'MM/DD/YYYY'}}
+                    {{else}}
+                        {{moment-format row.createdAt 'MM/DD/YYYY'}}
+                    {{/if}}
+                </td>
+                <td>
+                    {{#link-to "index" class="btn btn-default btn-xs" role="button"}}
+                        Edit
+                    {{/link-to}}
+                </td>
+            </tr>
+        {{/each}}
+    {{/if}}
+{{/ember-tabular}}
+
+<h5>Example #1</h5>
+<h1>Table - Persist Filtering</h1>
+{{#ember-tabular class="table-persist" tableWrapperClass="table-wrapper" paginationWrapperClass="pagination-wrapper" columns=columns modelName="user" record=users4 filter=filter3 persistFiltering=true sort=sort as |section|}}
+    {{#if section.isBody}}
+        {{#each users4 as |row|}}
             <tr>
                 <td>{{row.username}}</td>
                 <td>{{row.emailAddress}}</td>

--- a/tests/integration/ember-tabular-test.js
+++ b/tests/integration/ember-tabular-test.js
@@ -150,7 +150,7 @@ test('Render filter component', function(assert) {
   assert.equal($component.find('thead tr:eq(1) th:eq(1) input').length, 1, 'Table Filter Input - Email');
   assert.equal($component.find('thead tr:eq(1) th:eq(2) input').length, 1, 'Table Filter Input - First Name');
   assert.equal($component.find('thead tr:eq(1) th:eq(3) input').length, 1, 'Table Filter Input - Last Name');
-  assert.equal($component.find('thead tr:eq(1) th:eq(4) .ember-power-select').length, 1, 'Table Filter Input - Is Admin');
+  assert.equal($component.find('thead tr:eq(1) th:eq(4) .ember-power-select-trigger').length, 1, 'Table Filter Input - Is Admin');
   assert.equal($component.find('thead tr:eq(1) th:eq(5) input').length, 1, 'Table Filter Input - Last Updated');
   assert.equal($component.find('thead tr:eq(1) th:eq(6) input').length, 0, 'Table Filter No Input - Actions');
 });


### PR DESCRIPTION
#### What does this pull request do?
Bit of a nasty error on higher version of ember (not explicitly tested, but definitely effects the current ember release (2.10.0), ember-power-select fatally fails, has to be upgraded to the most recent stable version 1.0.0, which has a couple changes of its own, (like the `class` attribute not working the same way from 1.0.0.beta.14 to 1.0.0)
(**Note: Evaluation of its effects on other apps may need to be taken into account before accepted PR**)

#### What are the relevant issues?
N/A

#### Any background context you want to provide?
N/A

#### Definition of Done:
*Each should be selected to indicate consideration for applicability and/or completion.*

- [ ] Does this PR fully satisfy the scope as outlined in the referenced issue(s)?
- [x] Is there appropriate test coverage?
- [x] Is static analysis resulting in a satisfactory score?
- [x] If adding new dependencies, does pip requirements need to be updated?
- [x] Has the change log been updated?

