### PR TITLE
Fix bad column attribute reference in template

### DIFF
--- a/app/templates/components/ember-tabular.hbs
+++ b/app/templates/components/ember-tabular.hbs
@@ -45,7 +45,7 @@
                         {{#if showFilterRow}}
                             <tr>
                                 {{#each columns as |header|}}
-                                    {{#if header.filter}}
+                                    {{#if header.property}}
                                         {{ember-tabular-filter modelName=modelName columns=columns property=header.property record=record query=query filter=filter header=header}}
                                     {{else}}
                                         <th>{{!-- Blank to reserve table column --}}</th>


### PR DESCRIPTION
#### What does this pull request do?
Fixes bad reference to columns attribute that effects hiding the property input box if a column doesn't have a `property` attribute.

#### What are the relevant issues?
N/A

#### Any background context you want to provide?
N/A

#### Definition of Done:
*Each should be selected to indicate consideration for applicability and/or completion.*

- [x] Does this PR fully satisfy the scope as outlined in the referenced issue(s)?
- [x] Is there appropriate test coverage?
- [x] Is static analysis resulting in a satisfactory score?
- [x] If adding new dependencies\?
- [x] Has the change log been updated?
